### PR TITLE
🐛 Fix parentheses not being kept in AST

### DIFF
--- a/src/Ren/Compiler/Emit/CommonJS.elm
+++ b/src/Ren/Compiler/Emit/CommonJS.elm
@@ -326,6 +326,9 @@ fromExpression expression =
         Literal literal ->
             fromLiteral literal
 
+        SubExpression expr ->
+            fromSubExpression expr
+
 
 
 -- EMITTING EXPRESSIONS: ACCESS ------------------------------------------------
@@ -709,3 +712,14 @@ fromObjectField ( key, val ) =
     "{key}: {val}"
         |> String.replace "{key}" key
         |> String.replace "{val}" (fromExpression val)
+
+
+
+-- EMITTING EXPRESSIONS: SUBEXPRESSION -----------------------------------------------
+
+
+{-| -}
+fromSubExpression : Expression -> String
+fromSubExpression expression =
+    "({expr})"
+        |> String.replace "{expr}" (fromExpression expression)

--- a/src/Ren/Compiler/Emit/ESModule.elm
+++ b/src/Ren/Compiler/Emit/ESModule.elm
@@ -326,6 +326,8 @@ fromExpression expression =
         Literal literal ->
             fromLiteral literal
 
+        SubExpression expr ->
+            fromSubExpression expr
 
 
 -- EMITTING EXPRESSIONS: ACCESS ------------------------------------------------
@@ -709,3 +711,14 @@ fromObjectField ( key, val ) =
     "{key}: {val}"
         |> String.replace "{key}" key
         |> String.replace "{val}" (fromExpression val)
+
+
+
+-- EMITTING EXPRESSIONS: SUBEXPRESSION -----------------------------------------------
+
+
+{-| -}
+fromSubExpression : Expression -> String
+fromSubExpression expression =
+    "({expr})"
+        |> String.replace "{expr}" (fromExpression expression)

--- a/src/Ren/Data/Expression.elm
+++ b/src/Ren/Data/Expression.elm
@@ -118,6 +118,7 @@ type Expression
     | Infix Operator Expression Expression
     | Lambda (List Pattern) Expression
     | Literal Literal
+    | SubExpression Expression
 
 
 {-| An `Accessor` is what we use to access fields or indecies of an object or
@@ -658,6 +659,9 @@ referencesName name_ expression =
         Literal _ ->
             False
 
+        SubExpression expr ->
+            referencesName name_ expr
+
 
 {-| -}
 referencesScopedName : List String -> String -> Expression -> Bool
@@ -703,6 +707,9 @@ referencesScopedName namespace_ name_ expression =
 
         Literal _ ->
             False
+
+        SubExpression expr ->
+            referencesScopedName namespace_ name_ expr
 
 
 {-| -}
@@ -806,6 +813,9 @@ referencesModule namespace_ expression =
 
         Literal _ ->
             False
+
+        SubExpression expr ->
+            referencesModule namespace_ expr
 
 
 
@@ -991,7 +1001,7 @@ parser =
 {-| -}
 parenthesisedParser : Pratt.Config Expression -> Parser Expression
 parenthesisedParser prattConfig =
-    Parser.succeed identity
+    Parser.succeed SubExpression
         |. Parser.symbol "("
         |. Parser.spaces
         |= Pratt.subExpression 0 prattConfig

--- a/tests/Parse/Source/Expression.elm
+++ b/tests/Parse/Source/Expression.elm
@@ -30,8 +30,10 @@ suite =
             )
         , shouldSucceed "(f a) b"
             (Application
-                (Application (local "f")
-                    [ local "a" ]
+                (SubExpression
+                    (Application (local "f")
+                        [ local "a" ]
+                    )
                 )
                 [ local "b" ]
             )
@@ -69,6 +71,20 @@ suite =
                 (local "a")
                 (Application (local "f") [ local "b" ])
                 (local "c")
+            )
+        , shouldSucceed "3 + (if a then b else c) - 1"
+            (Infix Sub
+                (Infix Add
+                    (Literal (Number 3))
+                    (SubExpression
+                        (Conditional
+                            (Identifier (Local "a"))
+                            (Identifier (Local "b"))
+                            (Identifier (Local "c"))
+                        )
+                    )
+                )
+                (Literal (Number 1))
             )
         ]
 


### PR DESCRIPTION
Add SubExpression, optimise to strip parentheses around a single term.

Fixes #34 