### PR TITLE
✨ Implement pattern matching expressions.

### DIFF
--- a/src/Ren/Compiler/Emit/CommonJS.elm
+++ b/src/Ren/Compiler/Emit/CommonJS.elm
@@ -322,6 +322,9 @@ fromExpression expression =
         Literal literal ->
             fromLiteral literal
 
+        Match expr cases ->
+            fromMatch expr cases
+
         SubExpression expr ->
             fromSubExpression expr
 
@@ -700,6 +703,83 @@ fromObjectField ( key, val ) =
     "{key}: {val}"
         |> String.replace "{key}" key
         |> String.replace "{val}" (fromExpression val)
+
+
+
+-- EMITTING EXPRESSIONS: MATCH -------------------------------------------------
+
+
+{-| -}
+fromMatch : Expression -> List ( Pattern, Expression ) -> String
+fromMatch expr cases =
+    String.trimLeft """
+(($) => {
+    {cases}
+})({expr}) 
+"""
+        |> String.replace "{expr}" (fromExpression expr)
+        |> String.replace "{cases}" (fromCases cases |> String.Extra.nest 4 1)
+
+
+fromCases : List ( Pattern, Expression ) -> String
+fromCases cases =
+    List.map fromCase cases
+        |> String.join "\n"
+
+
+fromCase : ( Pattern, Expression ) -> String
+fromCase ( pattern, expr ) =
+    case pattern of
+        ArrayDestructure patterns ->
+            String.trimLeft """
+if (Array.isArray($) && $.length >= {length}) {
+    var {destructure} = $
+    return {expr}
+}          
+"""
+                |> String.replace "{length}" (String.fromInt <| List.length patterns)
+                |> String.replace "{destructure}" (fromArrayDestructure patterns)
+                |> String.replace "{expr}" (fromExpression expr)
+
+        Name name ->
+            String.trimLeft """
+if ($ === {name}) {
+    return {expr}
+}
+"""
+                |> String.replace "{name}" name
+                |> String.replace "{expr}" (fromExpression expr)
+
+        ObjectDestructure patterns ->
+            String.trimLeft """
+if (typeof $ === 'object' && {names}) {
+    var {destructure} = $
+    return {expr}
+}          
+"""
+                |> String.replace "{names}" (fromObjectDestructureNames patterns)
+                |> String.replace "{destructure}" (fromObjectDestructure patterns)
+                |> String.replace "{expr}" (fromExpression expr)
+
+        Value literal ->
+            String.trimLeft """
+if ($ === {literal}) {
+    return {expr}
+}
+"""
+                |> String.replace "{literal}" (fromPrimitiveLiteral literal)
+                |> String.replace "{expr}" (fromExpression expr)
+
+        Wildcard name ->
+            "_{name}"
+                |> String.replace "{name}" (Maybe.withDefault "" name)
+
+
+{-| -}
+fromObjectDestructureNames : List ( String, Maybe Pattern ) -> String
+fromObjectDestructureNames patterns =
+    List.map (\( name, _ ) -> name ++ " in $") patterns
+        |> String.join " && "
 
 
 

--- a/src/Ren/Compiler/Optimise/Expression.elm
+++ b/src/Ren/Compiler/Optimise/Expression.elm
@@ -80,6 +80,11 @@ recursiveTransformation transform expression =
         Literal literal ->
             Literal literal
 
+        Match expr patterns ->
+            Match
+                (transform expr)
+                (List.map (Tuple.mapSecond transform) patterns)
+
         SubExpression expr ->
             SubExpression (transform expr)
 

--- a/src/Ren/Compiler/Optimise/Expression.elm
+++ b/src/Ren/Compiler/Optimise/Expression.elm
@@ -83,7 +83,12 @@ recursiveTransformation transform expression =
         Match expr patterns ->
             Match
                 (transform expr)
-                (List.map (Tuple.mapSecond transform) patterns)
+                (List.map
+                    (\( pattern, guard, body ) ->
+                        ( pattern, Maybe.map transform guard, transform body )
+                    )
+                    patterns
+                )
 
         SubExpression expr ->
             SubExpression (transform expr)

--- a/src/Ren/Data/Expression.elm
+++ b/src/Ren/Data/Expression.elm
@@ -1176,8 +1176,6 @@ matchParser prattConfig =
         |. Parser.Extra.ignorables
         |= lazyParser
         |. Parser.Extra.ignorables
-        |. Parser.symbol "{"
-        |. Parser.Extra.ignorables
         |= Parser.loop []
             (\cases ->
                 Parser.oneOf
@@ -1191,8 +1189,6 @@ matchParser prattConfig =
                         |= Pratt.subExpression 0 prattConfig
                         |> Parser.map Parser.Loop
                     , Parser.succeed (List.reverse cases)
-                        |. Parser.Extra.ignorables
-                        |. Parser.symbol "}"
                         |> Parser.map Parser.Done
                     ]
             )

--- a/src/Ren/Data/Keywords.elm
+++ b/src/Ren/Data/Keywords.elm
@@ -28,6 +28,8 @@ import Set exposing (Set)
         , "ret"
         , "true"
         , "false"
+        , "match"
+        , "case"
         ]
 
 -}
@@ -46,6 +48,8 @@ all =
         , "ret"
         , "true"
         , "false"
+        , "match"
+        , "case"
         ]
 
 

--- a/src/Ren/Data/Keywords.elm
+++ b/src/Ren/Data/Keywords.elm
@@ -28,8 +28,8 @@ import Set exposing (Set)
         , "ret"
         , "true"
         , "false"
-        , "match"
-        , "case"
+        , "when"
+        , "is"
         ]
 
 -}
@@ -48,8 +48,8 @@ all =
         , "ret"
         , "true"
         , "false"
-        , "match"
-        , "case"
+        , "when"
+        , "is"
         ]
 
 

--- a/src/Ren/Samples/BottlesOfBeer.elm
+++ b/src/Ren/Samples/BottlesOfBeer.elm
@@ -1,0 +1,57 @@
+module Ren.Samples.BottlesOfBeer exposing (..)
+
+-- IMPORTS ---------------------------------------------------------------------
+
+import Parser
+import Ren.Compiler as Ren
+
+
+
+-- SOURCE ----------------------------------------------------------------------
+
+
+source : String
+source =
+    """
+import 'ren/array' as Array
+import 'ren/debug' as Debug
+
+// The `main` function is always the entry point to your program when being run
+// from Node. It receives `process.argv` as its only argument. We don't need it
+// for this program though, so we can safely ignore it!
+pub fun main = _ =>  {
+    // Declarations may be nested, but they *must all be declared at once*.
+    // Ren has no statements, so a function like this is always a list of
+    // declarations and then a single expression to be returned.
+    fun makeVerses = n => if n >= 0 then verse n :: makeVerses (n - 1) else []
+    let verses = makeVerses numberOfBottles
+
+    ret verses |> Array.forEach Debug.log
+}
+
+// Order of declaration is not significant in Ren, so we can declare the value
+// here but use it in `main` no problem.
+let numberOfBottles = 99
+
+// When a function has no local declarations, we can omit the curly braces and
+// the `ret` keyword and just write the return expression instead.
+fun verse = n => when n
+    is 0 =>
+        'No more bottles of beer on the wall, no more bottles of beer. ' +
+        'Go to the store and buy some more, 99 bottles of beer on the wall.'
+
+    is _ =>
+        bottles n + ' of beer on the wall, ' + bottles n + ' of beer. ' +
+        'Take one down and pass it around, ' + bottles (n - 1) + ' of beer on the wall.'
+
+
+fun bottles = n => when n
+    is 0 => 'no more bottles'
+    is 1 => '1 bottle'
+    else => n + ' bottles'
+"""
+
+
+ast : Result (List Parser.DeadEnd) Ren.Module
+ast =
+    Ren.parse source

--- a/tests/Parse/Source/Expression.elm
+++ b/tests/Parse/Source/Expression.elm
@@ -115,4 +115,65 @@ suite =
                 )
                 (Literal (Number 1))
             )
+        , shouldSucceed Expression.parser
+            "when foo is 10 => ()"
+            (Match (Identifier (Local "foo"))
+                [ ( Value (Number 10)
+                  , Nothing
+                  , Literal Undefined
+                  )
+                ]
+            )
+        , shouldSucceed Expression.parser
+            "when foo is [ x, y ] => ()"
+            (Match (Identifier (Local "foo"))
+                [ ( ArrayDestructure
+                        [ Name "x", Name "y" ]
+                  , Nothing
+                  , Literal Undefined
+                  )
+                ]
+            )
+        , shouldSucceed Expression.parser
+            "when foo is [ x, y ] if x > y => ()"
+            (Match (Identifier (Local "foo"))
+                [ ( ArrayDestructure [ Name "x", Name "y" ]
+                  , Infix Gt (Identifier (Local "x")) (Identifier (Local "y"))
+                        |> Just
+                  , Literal Undefined
+                  )
+                ]
+            )
+        , shouldSucceed Expression.parser
+            "when foo is [ x, y ] if x > y => () else => ()"
+            (Match (Identifier (Local "foo"))
+                [ ( ArrayDestructure [ Name "x", Name "y" ]
+                  , Infix Gt (Identifier (Local "x")) (Identifier (Local "y"))
+                        |> Just
+                  , Literal Undefined
+                  )
+                , ( Wildcard Nothing
+                  , Nothing
+                  , Literal Undefined
+                  )
+                ]
+            )
+        , shouldSucceed Expression.parser
+            "when foo is [ x, y ] if x > y => () is 10 => () else => ()"
+            (Match (Identifier (Local "foo"))
+                [ ( ArrayDestructure [ Name "x", Name "y" ]
+                  , Infix Gt (Identifier (Local "x")) (Identifier (Local "y"))
+                        |> Just
+                  , Literal Undefined
+                  )
+                , ( Value (Number 10)
+                  , Nothing
+                  , Literal Undefined
+                  )
+                , ( Wildcard Nothing
+                  , Nothing
+                  , Literal Undefined
+                  )
+                ]
+            )
         ]


### PR DESCRIPTION
Adds pattern matching to the language. Here are a handful of examples:

**Matching literals**:
```
when foo
    is 0 => 'foo is 0.'
    is 1 => 'foo is 1.'
    else => 'foo is something else.'
```

**Matching objects**:
```
when foo
    is { x, y, z } => 
        ...

    is { x, y } => 
        ...
```

**Matching different types**:
```
when foo
    is { x, y , z } => 
        ...

    is [ a, _, c ] => 
        ...

    is 'hello' => 
        ...
```

**Nested matches**:
```
when foo
    is { x, y, z } => (
        when x
            is 0 => ...
            else => ...
    )
```

**Boolean guards**:
```
when foo 
    is { x, y, z } if x > 0 =>
        ...
```

---

Todo:

- [x] Compile literal destructure patterns like `[ 0 ]` into equality checks
- [x] Add `if` clauses for arbitrary boolean conditions.

---

Closes #39 