### PR TITLE
🐛 Fix parentheses not being stripped all the time

### DIFF
--- a/src/Ren/Compiler/Optimise/Expression.elm
+++ b/src/Ren/Compiler/Optimise/Expression.elm
@@ -344,7 +344,6 @@ stripParentheses expression =
             SubExpression expr
                 |> Just
 
-
         -- ACCESS --------------------------------------------------------------
         -- Unwrap all SubExpressions inside Computed accessors.
         -- Removes [(expression)] output.
@@ -354,17 +353,19 @@ stripParentheses expression =
                     case acc of
                         Computed (SubExpression e) ->
                             Computed e
+
                         _ ->
                             acc
             in
-                List.map optimiseAccessor accessors
-                    |> (\optimisedAccessors ->
-                            if optimisedAccessors == accessors then
-                                Nothing
-                            else
-                                Access expr optimisedAccessors
-                                    |> Just
-                       )
+            List.map optimiseAccessor accessors
+                |> (\optimisedAccessors ->
+                        if optimisedAccessors == accessors then
+                            Nothing
+
+                        else
+                            Access expr optimisedAccessors
+                                |> Just
+                   )
 
         -- APPLICATION ---------------------------------------------------------
         -- Unwrap all SubExpressions as arguments.
@@ -375,17 +376,19 @@ stripParentheses expression =
                     case arg of
                         SubExpression e ->
                             e
+
                         _ ->
                             arg
             in
-                List.map optimiseArgument arguments
-                    |> (\optimisedArguments ->
-                            if optimisedArguments == arguments then
-                                Nothing
-                            else
-                                Application func optimisedArguments
-                                    |> Just
-                       )
+            List.map optimiseArgument arguments
+                |> (\optimisedArguments ->
+                        if optimisedArguments == arguments then
+                            Nothing
+
+                        else
+                            Application func optimisedArguments
+                                |> Just
+                   )
 
         -- CONDITIONAL ---------------------------------------------------------
         -- Unwrap all SubExpressions as condition.
@@ -411,7 +414,7 @@ stripParentheses expression =
         -- Prevents body being wrappped in parentheses.
         Lambda patterns (SubExpression body) ->
             Lambda patterns body
-             |> Just
+                |> Just
 
         -- MATCH ---------------------------------------------------------------
         -- Unwrap all SubExpressions as arguments.

--- a/src/Ren/Compiler/Optimise/Expression.elm
+++ b/src/Ren/Compiler/Optimise/Expression.elm
@@ -326,6 +326,8 @@ constantFold expression =
 stripParentheses : Expression -> Maybe Expression
 stripParentheses expression =
     case expression of
+        -- SUBEXPRESSION -------------------------------------------------------
+        -- Unwrap all SubExpressions with single expression contents
         SubExpression (Access expr accessors) ->
             Access expr accessors
                 |> Just
@@ -340,6 +342,82 @@ stripParentheses expression =
 
         SubExpression (SubExpression expr) ->
             SubExpression expr
+                |> Just
+
+
+        -- ACCESS --------------------------------------------------------------
+        -- Unwrap all SubExpressions inside Computed accessors.
+        -- Removes [(expression)] output.
+        Access expr accessors ->
+            let
+                optimiseAccessor acc =
+                    case acc of
+                        Computed (SubExpression e) ->
+                            Computed e
+                        _ ->
+                            acc
+            in
+                List.map optimiseAccessor accessors
+                    |> (\optimisedAccessors ->
+                            if optimisedAccessors == accessors then
+                                Nothing
+                            else
+                                Access expr optimisedAccessors
+                                    |> Just
+                       )
+
+        -- APPLICATION ---------------------------------------------------------
+        -- Unwrap all SubExpressions as arguments.
+        -- Prevents arguments being wrappped in double-parentheses.
+        Application func arguments ->
+            let
+                optimiseArgument arg =
+                    case arg of
+                        SubExpression e ->
+                            e
+                        _ ->
+                            arg
+            in
+                List.map optimiseArgument arguments
+                    |> (\optimisedArguments ->
+                            if optimisedArguments == arguments then
+                                Nothing
+                            else
+                                Application func optimisedArguments
+                                    |> Just
+                       )
+
+        -- CONDITIONAL ---------------------------------------------------------
+        -- Unwrap all SubExpressions as condition.
+        -- Prevents condition being wrappped in double-parentheses.
+        Conditional (SubExpression condition) trueCase falseCase ->
+            Conditional condition trueCase falseCase
+                |> Just
+
+        -- Unwrap all SubExpressions as body if true.
+        -- Prevents true body being wrappped in parentheses.
+        Conditional condition (SubExpression trueCase) falseCase ->
+            Conditional condition trueCase falseCase
+                |> Just
+
+        -- Unwrap all SubExpressions as body if false.
+        -- Prevents false body being wrappped in parentheses.
+        Conditional condition trueCase (SubExpression falseCase) ->
+            Conditional condition trueCase falseCase
+                |> Just
+
+        -- LAMBDA --------------------------------------------------------------
+        -- Unwrap SubExpression as body.
+        -- Prevents body being wrappped in parentheses.
+        Lambda patterns (SubExpression body) ->
+            Lambda patterns body
+             |> Just
+
+        -- MATCH ---------------------------------------------------------------
+        -- Unwrap all SubExpressions as arguments.
+        -- Prevents arguments being wrappped in double-parentheses.
+        Match (SubExpression expr) branches ->
+            Match expr branches
                 |> Just
 
         _ ->


### PR DESCRIPTION
Fixes #52.

Strips parentheses inside single-term expressions (anything with a subexpression which isn't an infix operator).
May need revisiting if/when alternative emit targets are added.

`> Expression.fromSource "f (a) (b + c)" |> Result.map (optimiseExpression >> (emitExpression ESModule))
Ok ("f (a) (b + c)") : Result (List Parser.DeadEnd) String
> Expression.fromSource "fun a b => (a + b)" |> Result.map (optimiseExpression >> (emitExpression ESModule))
Ok ("(a) => (b) => a + b") : Result (List Parser.DeadEnd) String
> Expression.fromSource "if (a) then (b) else (c)" |> Result.map (optimiseExpression >> (emitExpression ESModule))
Ok ("a\n    ? b\n    : c") : Result (List Parser.DeadEnd) String
> Expression.fromSource "when (a + b) is 2 => a else => b" |> Result.map (optimiseExpression >> (emitExpression ESModule))
Ok ("(($) => {\n    if ($ == 2) {\n        return a\n    }\n\n    return b\n})(a + b)")`