### PR TITLE
🐛 Add support for escaped backslashes in strings

### DIFF
--- a/src/Parser/Extra.elm
+++ b/src/Parser/Extra.elm
@@ -30,6 +30,7 @@ string quoteChar =
                             [ Parser.succeed "\n" |. Parser.token "n"
                             , Parser.succeed "\t" |. Parser.token "t"
                             , Parser.succeed "\u{000D}" |. Parser.token "r"
+                            , Parser.succeed "\\" |. Parser.token "\\"
                             , Parser.succeed quoteString |. Parser.token quoteString
                             ]
                         |> Parser.map Parser.Loop


### PR DESCRIPTION
Minor oversight, no way to escape backslashes in strings.

Didn't deem it large enough for an Issue, but didn't want to push directly to main.