### PR TITLE
✨ Optimisations are applied to `Template` literals correctly.

### DIFF
--- a/src/Ren/Compiler/Optimise/Expression.elm
+++ b/src/Ren/Compiler/Optimise/Expression.elm
@@ -77,6 +77,21 @@ recursiveTransformation transform expression =
             Literal
                 (Object <| Dict.map (always transform) fields)
 
+        Literal (Template segments) ->
+            Literal
+                (Template <|
+                    List.map
+                        (\segment ->
+                            case segment of
+                                Literal.Text text ->
+                                    Literal.Text text
+
+                                Literal.Expr expr ->
+                                    Literal.Expr (transform expr)
+                        )
+                        segments
+                )
+
         Literal literal ->
             Literal literal
 

--- a/src/Ren/Data/Expression.elm
+++ b/src/Ren/Data/Expression.elm
@@ -641,6 +641,25 @@ referencesName name_ expression =
         Lambda _ body ->
             referencesName name_ body
 
+        Literal (Literal.Array elements) ->
+            List.any (referencesName name_) elements
+
+        Literal (Literal.Object entries) ->
+            Dict.toList entries
+                |> List.any (Tuple.second >> referencesName name_)
+
+        Literal (Literal.Template segments) ->
+            List.any
+                (\segment ->
+                    case segment of
+                        Literal.Text _ ->
+                            False
+
+                        Literal.Expr expr ->
+                            referencesName name_ expr
+                )
+                segments
+
         Literal _ ->
             False
 
@@ -696,6 +715,25 @@ referencesScopedName namespace_ name_ expression =
 
         Lambda _ body ->
             referencesScopedName namespace_ name_ body
+
+        Literal (Literal.Array elements) ->
+            List.any (referencesScopedName namespace_ name_) elements
+
+        Literal (Literal.Object entries) ->
+            Dict.toList entries
+                |> List.any (Tuple.second >> referencesScopedName namespace_ name_)
+
+        Literal (Literal.Template segments) ->
+            List.any
+                (\segment ->
+                    case segment of
+                        Literal.Text _ ->
+                            False
+
+                        Literal.Expr expr ->
+                            referencesScopedName namespace_ name_ expr
+                )
+                segments
 
         Literal _ ->
             False
@@ -806,6 +844,25 @@ referencesModule namespace_ expression =
 
         Lambda _ body ->
             referencesModule namespace_ body
+
+        Literal (Literal.Array elements) ->
+            List.any (referencesModule namespace_) elements
+
+        Literal (Literal.Object entries) ->
+            Dict.toList entries
+                |> List.any (Tuple.second >> referencesModule namespace_)
+
+        Literal (Literal.Template segments) ->
+            List.any
+                (\segment ->
+                    case segment of
+                        Literal.Text _ ->
+                            False
+
+                        Literal.Expr expr ->
+                            referencesModule namespace_ expr
+                )
+                segments
 
         Literal _ ->
             False


### PR DESCRIPTION
Closes #59 and #62.