### PR TITLE
⚡Don't emit 'undefined' argument inside function application

### DIFF
--- a/src/Ren/Compiler/Emit/ESModule.elm
+++ b/src/Ren/Compiler/Emit/ESModule.elm
@@ -27,7 +27,8 @@ fromModule { imports, declarations } =
     if List.isEmpty imports then
         declarations
             |> List.map (fromDeclaration >> Pretty.a Pretty.line)
-            |> Pretty.lines 
+            |> Pretty.lines
+
     else
         Pretty.lines (List.map fromImport imports)
             |> Pretty.a Pretty.line
@@ -300,11 +301,22 @@ fromApplication expr args =
         |> Pretty.a Pretty.space
         |> Pretty.a
             (args
-                |> List.map (fromExpression >> Pretty.parens)
+                |> List.map fromArgument
                 |> Pretty.lines
             )
         |> Pretty.group
         |> Pretty.nest 4
+
+
+fromArgument : Expression -> Pretty.Doc t
+fromArgument arg =
+    case arg of
+        Literal Undefined ->
+            Pretty.string "()"
+
+        _ ->
+            fromExpression arg
+                |> Pretty.parens
 
 
 


### PR DESCRIPTION
Currently application of a function with no argument `f ()` compiles to `f (undefined)`.

This changes it to emit the more usual JS: `f ()`