### PR TITLE
⚡Remove SubExpression type

### DIFF
--- a/src/Ren/Compiler/Emit/ESModule.elm
+++ b/src/Ren/Compiler/Emit/ESModule.elm
@@ -27,7 +27,7 @@ fromModule { imports, declarations } =
     if List.isEmpty imports then
         declarations
             |> List.map (fromDeclaration >> Pretty.a Pretty.line)
-            |> Pretty.lines 
+            |> Pretty.lines
     else
         Pretty.lines (List.map fromImport imports)
             |> Pretty.a Pretty.line
@@ -265,9 +265,19 @@ fromExpression expression =
         Match expr cases ->
             fromMatch expr cases
 
-        SubExpression expr ->
-            fromSubexpression expr
 
+fromExpressionToSingleTerm : Expression -> Pretty.Doc t
+fromExpressionToSingleTerm expression =
+    case expression of
+        Application expr args ->
+            fromApplication expr args
+                |> Pretty.parens
+
+        Infix operator lhs rhs ->
+            fromInfix operator lhs rhs
+                |> Pretty.parens
+
+        _ -> fromExpression expression
 
 
 -- EMITTING EXPRESSIONS: ACCESS ------------------------------------------------
@@ -275,7 +285,7 @@ fromExpression expression =
 
 fromAccess : Expression -> List Accessor -> Pretty.Doc t
 fromAccess expr accessors =
-    fromExpression expr
+    fromExpressionToSingleTerm expr
         |> Pretty.a (Pretty.join Pretty.empty <| List.map fromAccessor accessors)
 
 
@@ -296,7 +306,7 @@ fromAccessor accessor =
 
 fromApplication : Expression -> List Expression -> Pretty.Doc t
 fromApplication expr args =
-    fromExpression expr
+    fromExpressionToSingleTerm expr
         |> Pretty.a Pretty.space
         |> Pretty.a
             (args
@@ -454,86 +464,86 @@ fromInfix operator lhs rhs =
                 |> Pretty.parens
 
         Add ->
-            fromExpression lhs
+            fromExpressionToSingleTerm lhs
                 |> Pretty.a (Pretty.string " + ")
-                |> Pretty.a (fromExpression rhs)
+                |> Pretty.a (fromExpressionToSingleTerm rhs)
 
         Sub ->
-            fromExpression lhs
+            fromExpressionToSingleTerm lhs
                 |> Pretty.a (Pretty.string " - ")
-                |> Pretty.a (fromExpression rhs)
+                |> Pretty.a (fromExpressionToSingleTerm rhs)
 
         Mul ->
-            fromExpression lhs
+            fromExpressionToSingleTerm lhs
                 |> Pretty.a (Pretty.string " * ")
-                |> Pretty.a (fromExpression rhs)
+                |> Pretty.a (fromExpressionToSingleTerm rhs)
 
         Div ->
-            fromExpression lhs
+            fromExpressionToSingleTerm lhs
                 |> Pretty.a (Pretty.string " / ")
-                |> Pretty.a (fromExpression rhs)
+                |> Pretty.a (fromExpressionToSingleTerm rhs)
 
         Pow ->
-            fromExpression lhs
+            fromExpressionToSingleTerm lhs
                 |> Pretty.a (Pretty.string " ** ")
-                |> Pretty.a (fromExpression rhs)
+                |> Pretty.a (fromExpressionToSingleTerm rhs)
 
         Mod ->
-            fromExpression lhs
+            fromExpressionToSingleTerm lhs
                 |> Pretty.a (Pretty.string " % ")
-                |> Pretty.a (fromExpression rhs)
+                |> Pretty.a (fromExpressionToSingleTerm rhs)
 
         Eq ->
-            fromExpression lhs
+            fromExpressionToSingleTerm lhs
                 |> Pretty.a (Pretty.string " == ")
-                |> Pretty.a (fromExpression rhs)
+                |> Pretty.a (fromExpressionToSingleTerm rhs)
 
         NotEq ->
-            fromExpression lhs
+            fromExpressionToSingleTerm lhs
                 |> Pretty.a (Pretty.string " != ")
-                |> Pretty.a (fromExpression rhs)
+                |> Pretty.a (fromExpressionToSingleTerm rhs)
 
         Lt ->
-            fromExpression lhs
+            fromExpressionToSingleTerm lhs
                 |> Pretty.a (Pretty.string " < ")
-                |> Pretty.a (fromExpression rhs)
+                |> Pretty.a (fromExpressionToSingleTerm rhs)
 
         Lte ->
-            fromExpression lhs
+            fromExpressionToSingleTerm lhs
                 |> Pretty.a (Pretty.string " <= ")
-                |> Pretty.a (fromExpression rhs)
+                |> Pretty.a (fromExpressionToSingleTerm rhs)
 
         Gt ->
-            fromExpression lhs
+            fromExpressionToSingleTerm lhs
                 |> Pretty.a (Pretty.string " > ")
-                |> Pretty.a (fromExpression rhs)
+                |> Pretty.a (fromExpressionToSingleTerm rhs)
 
         Gte ->
-            fromExpression lhs
+            fromExpressionToSingleTerm lhs
                 |> Pretty.a (Pretty.string " >= ")
-                |> Pretty.a (fromExpression rhs)
+                |> Pretty.a (fromExpressionToSingleTerm rhs)
 
         And ->
-            fromExpression lhs
+            fromExpressionToSingleTerm lhs
                 |> Pretty.a (Pretty.string " && ")
-                |> Pretty.a (fromExpression rhs)
+                |> Pretty.a (fromExpressionToSingleTerm rhs)
 
         Or ->
-            fromExpression lhs
+            fromExpressionToSingleTerm lhs
                 |> Pretty.a (Pretty.string " || ")
-                |> Pretty.a (fromExpression rhs)
+                |> Pretty.a (fromExpressionToSingleTerm rhs)
 
         Cons ->
-            fromExpression lhs
+            fromExpressionToSingleTerm lhs
                 |> Pretty.a (Pretty.string ", ...")
-                |> Pretty.a (fromExpression rhs)
+                |> Pretty.a (fromExpressionToSingleTerm rhs)
                 |> Pretty.brackets
 
         Join ->
             Pretty.string "..."
-                |> Pretty.a (fromExpression lhs)
+                |> Pretty.a (fromExpressionToSingleTerm lhs)
                 |> Pretty.a (Pretty.string ", ...")
-                |> Pretty.a (fromExpression rhs)
+                |> Pretty.a (fromExpressionToSingleTerm rhs)
                 |> Pretty.brackets
 
 
@@ -1246,16 +1256,6 @@ matchPatternsFromObjectDestructure path patterns =
                         ]
             )
         |> (::) (IsObject path)
-
-
-
--- EMITTING EXPRESSIONS: SUBEXPRESSION -----------------------------------------
-
-
-fromSubexpression : Expression -> Pretty.Doc t
-fromSubexpression expr =
-    fromExpression expr
-        |> Pretty.parens
 
 
 

--- a/src/Ren/Compiler/Emit/ESModule.elm
+++ b/src/Ren/Compiler/Emit/ESModule.elm
@@ -28,6 +28,7 @@ fromModule { imports, declarations } =
         declarations
             |> List.map (fromDeclaration >> Pretty.a Pretty.line)
             |> Pretty.lines
+
     else
         Pretty.lines (List.map fromImport imports)
             |> Pretty.a Pretty.line
@@ -273,11 +274,17 @@ fromExpressionToSingleTerm expression =
             fromApplication expr args
                 |> Pretty.parens
 
+        Conditional condition true false ->
+            fromConditional condition true false
+                |> Pretty.parens
+
         Infix operator lhs rhs ->
             fromInfix operator lhs rhs
                 |> Pretty.parens
 
-        _ -> fromExpression expression
+        _ ->
+            fromExpression expression
+
 
 
 -- EMITTING EXPRESSIONS: ACCESS ------------------------------------------------

--- a/src/Ren/Compiler/Optimise.elm
+++ b/src/Ren/Compiler/Optimise.elm
@@ -208,7 +208,6 @@ optimiseExpression =
 expressionDefaults : List (Expression -> Maybe Expression)
 expressionDefaults =
     [ constantFold
-    -- , stripParentheses
     ]
 
 

--- a/src/Ren/Compiler/Optimise.elm
+++ b/src/Ren/Compiler/Optimise.elm
@@ -208,7 +208,7 @@ optimiseExpression =
 expressionDefaults : List (Expression -> Maybe Expression)
 expressionDefaults =
     [ constantFold
-    , stripParentheses
+    -- , stripParentheses
     ]
 
 
@@ -258,10 +258,6 @@ transformExpression transform expression =
             Match
                 (transform expr)
                 (List.map (transformCase transform) cases)
-
-        SubExpression expr ->
-            SubExpression
-                (transform expr)
 
 
 transformAccessor : (Expression -> Expression) -> Accessor -> Accessor
@@ -536,110 +532,6 @@ constantFold expression =
         Infix Join (Literal (Array a)) (Literal (Array b)) ->
             Just (a ++ b)
                 |> Maybe.map (Array >> Literal)
-
-        _ ->
-            Nothing
-
-
-stripParentheses : Expression -> Maybe Expression
-stripParentheses expression =
-    case expression of
-        -- SUBEXPRESSION -------------------------------------------------------
-        -- Unwrap all SubExpressions with single expression contents
-        SubExpression (Access expr accessors) ->
-            Access expr accessors
-                |> Just
-
-        SubExpression (Identifier id) ->
-            Identifier id
-                |> Just
-
-        SubExpression (Literal literal) ->
-            Literal literal
-                |> Just
-
-        SubExpression (SubExpression expr) ->
-            SubExpression expr
-                |> Just
-
-        -- ACCESS --------------------------------------------------------------
-        -- Unwrap all SubExpressions inside Computed accessors.
-        -- Removes [(expression)] output.
-        Access expr accessors ->
-            let
-                optimiseAccessor acc =
-                    case acc of
-                        Computed (SubExpression e) ->
-                            Computed e
-
-                        _ ->
-                            acc
-            in
-            List.map optimiseAccessor accessors
-                |> (\optimisedAccessors ->
-                        if optimisedAccessors == accessors then
-                            Nothing
-
-                        else
-                            Access expr optimisedAccessors
-                                |> Just
-                   )
-
-        -- APPLICATION ---------------------------------------------------------
-        -- Unwrap all SubExpressions as arguments.
-        -- Prevents arguments being wrappped in double-parentheses.
-        Application func arguments ->
-            let
-                optimiseArgument arg =
-                    case arg of
-                        SubExpression e ->
-                            e
-
-                        _ ->
-                            arg
-            in
-            List.map optimiseArgument arguments
-                |> (\optimisedArguments ->
-                        if optimisedArguments == arguments then
-                            Nothing
-
-                        else
-                            Application func optimisedArguments
-                                |> Just
-                   )
-
-        -- CONDITIONAL ---------------------------------------------------------
-        -- Unwrap all SubExpressions as condition.
-        -- Prevents condition being wrappped in double-parentheses.
-        Conditional (SubExpression condition) trueCase falseCase ->
-            Conditional condition trueCase falseCase
-                |> Just
-
-        -- Unwrap all SubExpressions as body if true.
-        -- Prevents true body being wrappped in parentheses.
-        Conditional condition (SubExpression trueCase) falseCase ->
-            Conditional condition trueCase falseCase
-                |> Just
-
-        -- Unwrap all SubExpressions as body if false.
-        -- Prevents false body being wrappped in parentheses.
-        Conditional condition trueCase (SubExpression falseCase) ->
-            Conditional condition trueCase falseCase
-                |> Just
-
-        -- LAMBDA --------------------------------------------------------------
-        -- Unwrap SubExpression as body.
-        -- Prevents body being wrappped in parentheses.
-        Lambda patterns (SubExpression body) ->
-            Lambda patterns body
-                |> Just
-
-        -- MATCH ---------------------------------------------------------------
-        -- Unwrap all SubExpressions as arguments.
-        -- Prevents arguments being wrappped in double-parentheses.
-        Match (SubExpression expr) branches ->
-            Match expr branches
-                |> Just
 
         _ ->
             Nothing

--- a/src/Ren/Compiler/Parse.elm
+++ b/src/Ren/Compiler/Parse.elm
@@ -338,7 +338,7 @@ expressionParser =
 {-| -}
 parenthesisedExpressionParser : Pratt.Config Expression -> Parser Expression
 parenthesisedExpressionParser prattConfig =
-    Parser.succeed SubExpression
+    Parser.succeed identity
         |. Parser.symbol "("
         |. Parser.Extra.ignorables
         |= Pratt.subExpression 0 prattConfig

--- a/src/Ren/Language.elm
+++ b/src/Ren/Language.elm
@@ -124,7 +124,6 @@ type Expression
     | Lambda (List Pattern) Expression
     | Literal Literal
     | Match Expression (List ( Pattern, Maybe Expression, Expression ))
-    | SubExpression Expression
 
 
 {-| -}

--- a/src/Ren/Language/Expression.elm
+++ b/src/Ren/Language/Expression.elm
@@ -191,9 +191,6 @@ references name expression =
             references name expr
                 || List.any (referencesInCase name) cases
 
-        SubExpression expr ->
-            references name expr
-
 
 referencesInAccessor : String -> Accessor -> Bool
 referencesInAccessor name accessor =
@@ -287,9 +284,6 @@ referencesNamespace namespace expression =
             referencesNamespace namespace expr
                 || List.any (referencesNamespaceInCase namespace) cases
 
-        SubExpression expr ->
-            referencesNamespace namespace expr
-
 
 referencesNamespaceInAccessor : List String -> Accessor -> Bool
 referencesNamespaceInAccessor namespace accessor =
@@ -382,9 +376,6 @@ referencesQualified namespace name expression =
         Match expr cases ->
             referencesQualified namespace name expr
                 || List.any (referencesQualifiedInCase namespace name) cases
-
-        SubExpression expr ->
-            referencesQualified namespace name expr
 
 
 referencesQualifiedInAccessor : List String -> String -> Accessor -> Bool

--- a/tests/Parse/Source/Expression.elm
+++ b/tests/Parse/Source/Expression.elm
@@ -34,10 +34,8 @@ suite =
         , shouldSucceed Expression.parser
             "(f a) b"
             (Application
-                (SubExpression
-                    (Application (local "f")
-                        [ local "a" ]
-                    )
+                (Application (local "f")
+                    [ local "a" ]
                 )
                 [ local "b" ]
             )
@@ -105,12 +103,10 @@ suite =
             (Infix Sub
                 (Infix Add
                     (Literal (Number 3))
-                    (SubExpression
-                        (Conditional
-                            (Identifier (Local "a"))
-                            (Identifier (Local "b"))
-                            (Identifier (Local "c"))
-                        )
+                    (Conditional
+                        (Identifier (Local "a"))
+                        (Identifier (Local "b"))
+                        (Identifier (Local "c"))
                     )
                 )
                 (Literal (Number 1))


### PR DESCRIPTION
Remove hacky SubExpression Expression type (which was just a wrapper around an Expression)

TODO:
- [x] Remove SubExpression
- [x] Remove SubExpression specific optimisations
- [x] Fix tests using SubExpression
- [x] Fix parentheses always being inserted around "sub-expressions" which require a single term (see below)

Known issues:
Parentheses will always be inserted around sub-expressions which are not a single term (i.e. application and infix operators).
This results in output like the following: `a + b + c` -> `(a + b) + c`

Example output:
![image](https://user-images.githubusercontent.com/1474110/140361252-b9ef4a0c-fa40-4f98-8644-eea48ae0a617.png)