### PR TITLE
Begin reimplementing emit optimisations

### DIFF
--- a/src/Ren/Compiler/Emit/ESModule.elm
+++ b/src/Ren/Compiler/Emit/ESModule.elm
@@ -409,12 +409,10 @@ infix_ op lhs rhs =
                 _ ->
                     Nothing
 
-        wrapLowerPrecedence { wrap, precedence, expr } =
+        wrapLowerPrecedence { precedence, expr } =
             case Maybe.map2 (\child parent -> child < parent) precedence esPrecedence of
                 Just True ->
-                    -- Should this just always Pretty.parens?
-                    -- I will leave it like this until we overhaul the wrap function
-                    wrap expr
+                    Pretty.parens expr
 
                 _ ->
                     expr


### PR DESCRIPTION
Added precedence to `Builder`
Partial solution for #99.
`pub let main = _ => [(foo + bar) * 3, ((foo + bar) * 3), foo + (bar * 3), foo + bar * 3]`

now becomes:
```js
// main :: *
export function main (_) {
    return [(foo + bar) * 3, (foo + bar) * 3, foo + bar * 3, foo + bar * 3]
}
```